### PR TITLE
Fixed issue with reset connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 config.json
+testdata.txt

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(Windows) Launch",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/target/debug/linkstation-monitor.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": true
+        }
+    ]
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,23 +1,52 @@
-use std::io::{Write, Error, ErrorKind};
+use std::io::{Error, ErrorKind, Write};
 use std::net::TcpStream;
 use std::string::ToString;
 use std::thread;
 
 use crate::config::Config;
 
+use mqtt::control::fixed_header::FixedHeaderError;
 use mqtt::control::variable_header::ConnectReturnCode;
-use mqtt::{Encodable, Decodable};
 use mqtt::packet::*;
 use mqtt::TopicName;
+use mqtt::{Decodable, Encodable};
 
 pub struct MQTTServer {
-    stream: TcpStream,
+    server_addr: String,
+    user_name: String,
+    password: String,
+    stream: Option<TcpStream>,
 }
 
 impl MQTTServer {
-    pub fn connect(config: Config) -> Result<MQTTServer,Error> {
-        info!("Connecting to {:?} ... ", config.server_addr);
-        let mut stream = TcpStream::connect(config.server_addr)?;
+    pub fn connect(config: Config) -> Result<MQTTServer, Error> {
+        let result = MQTTServer {
+            server_addr: config.server_addr,
+            user_name: config.user_name,
+            password: config.password,
+            stream: None,
+        };
+        result.try_reconnect()
+    }
+
+    pub fn reconnect(self) -> MQTTServer {
+        match self.try_reconnect() {
+            Ok(s) => s,
+            Err(e) => {
+                error!("Couldn't reconnect to broker! {:?}", e);
+                MQTTServer {
+                    server_addr: self.server_addr,
+                    user_name: self.user_name,
+                    password: self.password,
+                    stream: None,
+                }
+            }
+        }
+    }
+
+    pub fn try_reconnect(&self) -> Result<MQTTServer, Error> {
+        info!("Connecting to {:?} ... ", self.server_addr);
+        let mut stream = TcpStream::connect(self.server_addr.clone())?;
         info!("Connected!");
 
         let client_id = "lsm_test_client";
@@ -25,15 +54,18 @@ impl MQTTServer {
 
         let mut conn = ConnectPacket::new("MQTT", client_id);
         conn.set_clean_session(true);
-        conn.set_user_name(Some(config.user_name));
-        conn.set_password(Some(config.password));
-        
+        conn.set_user_name(Some(self.user_name.clone()));
+        conn.set_password(Some(self.password.clone()));
+
         let mut buf = Vec::new();
         match conn.encode(&mut buf) {
             Ok(k) => k,
             Err(error) => {
                 error!("Could not encode Connection packet: {:?}", error);
-                return Err(Error::new(ErrorKind::InvalidData, "Could not encode Connection packet"));
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "Could not encode Connection packet",
+                ));
             }
         };
         stream.write_all(&buf[..])?;
@@ -45,7 +77,10 @@ impl MQTTServer {
             }
             Err(error) => {
                 error!("Unable to decode CONNACK packet! {:?}", error);
-                return Err(Error::new(ErrorKind::NotConnected, "Unable to decode CONNACK packet"));
+                return Err(Error::new(
+                    ErrorKind::NotConnected,
+                    "Unable to decode CONNACK packet",
+                ));
             }
         };
 
@@ -54,63 +89,124 @@ impl MQTTServer {
                 "Failed to connect to server, return code {:?}",
                 connack.connect_return_code()
             );
-            return Err(Error::new(ErrorKind::NotConnected, "Failed to connect to server"));
+            return Err(Error::new(
+                ErrorKind::NotConnected,
+                "Failed to connect to server",
+            ));
         }
 
         let server = MQTTServer {
-            stream: stream
+            server_addr: self.server_addr.clone(),
+            user_name: self.user_name.clone(),
+            password: self.password.clone(),
+            stream: Some(stream),
         };
         Ok(server)
     }
 
-    pub fn start(self) -> Result<MQTTServer,String> {
-        let mut cloned_stream = self.stream.try_clone().unwrap();
-        thread::spawn(move || {
-            loop {
-                let packet = match VariablePacket::decode(&mut cloned_stream) {
-                    Ok(pk) => pk,
-                    Err(err) => {
-                        error!("Error in receiving packet {:?}", err);
-                        continue;
-                    }
-                };
-                trace!("PACKET {:?}", packet);
+    pub fn start(self) -> Result<MQTTServer, String> {
+        if let Some(stream) = &self.stream { 
+            let mut cloned_stream = stream.try_clone().unwrap();
+            thread::spawn(move || {
+                loop {
+                    let packet = match VariablePacket::decode(&mut cloned_stream) {
+                        Ok(pk) => pk,
+                        Err(error) => {
+                            match handle_packet_receive_error(error) {
+                                PacketReceiveError::ConnectionReset => {
+                                    warn!("Receive thread terminating due to ConnectionReset!");
+                                    break;
+                                }
+                                PacketReceiveError::Other => continue
+                            }
+                        }
+                    };
+                    trace!("PACKET {:?}", packet);
 
-                match packet {
-                    VariablePacket::PingreqPacket(..) => {
-                        let pingresp = PingrespPacket::new();
-                        info!("Sending Ping response {:?}", pingresp);
-                        pingresp.encode(&mut cloned_stream).unwrap();
-                    }
-                    VariablePacket::DisconnectPacket(..) => {
-                        break;
-                    }
-                    _ => {
-                        // Ignore other packets in pub client
+                    match packet {
+                        VariablePacket::PingreqPacket(..) => {
+                            let pingresp = PingrespPacket::new();
+                            info!("Sending Ping response {:?}", pingresp);
+                            pingresp.encode(&mut cloned_stream).unwrap();
+                        }
+                        VariablePacket::DisconnectPacket(..) => {
+                            break;
+                        }
+                        _ => {
+                            // Ignore other packets in pub client
+                        }
                     }
                 }
-            }
-        });
+            });
+        }
 
-        let result = MQTTServer {
-            stream: self.stream
-        };
-        Ok(result)
+        Ok(self)
     }
 
-    pub fn publish<M: Into<Vec<u8>>>(&mut self, topic: &str, message: M) -> Result<(),std::io::Error> {
+    pub fn publish<M: Into<Vec<u8>>>(
+        &mut self,
+        topic: &str,
+        message: M,
+    ) -> Result<(), std::io::Error> {
         // Create a new Publish packet
-        let mut packet = PublishPacket::new(TopicName::new(topic).unwrap(),
-                                    QoSWithPacketIdentifier::Level0,
-                                    message);
+        let mut packet = PublishPacket::new(
+            TopicName::new(topic).unwrap(),
+            QoSWithPacketIdentifier::Level0,
+            message,
+        );
         packet.set_retain(true);
         let mut buf = Vec::new();
         packet.encode(&mut buf).unwrap();
-        self.stream.write_all(&buf[..])
+        match &self.stream {
+            Some(stream) => {
+                let mut stream = stream;
+                stream.write_all(&buf[..])
+            },
+            None => Err(std::io::Error::new(ErrorKind::ConnectionReset, "Cannot send because TcpStream was reset and never reconnected!")),
+        }
     }
 
-    pub fn publish_value<V: ToString>(&mut self, topic: &str, value: V) -> Result<(),std::io::Error> {
+    pub fn publish_value<V: ToString>(
+        &mut self,
+        topic: &str,
+        value: V,
+    ) -> Result<(), std::io::Error> {
         let message = value.to_string();
         self.publish(topic, message.as_bytes().to_vec())
     }
+}
+
+enum PacketReceiveError {
+    ConnectionReset,
+    Other,
+}
+
+fn handle_packet_receive_error(error: VariablePacketError) -> PacketReceiveError {
+    match error {
+        VariablePacketError::IoError(io_err) => {
+            if let ErrorKind::ConnectionReset = io_err.kind() {
+                warn!("Connection to MQTT broker was reset!");
+                return PacketReceiveError::ConnectionReset;
+            } else {
+                error!("Unexpected IoError! {:?}", io_err);
+            }
+        }
+        VariablePacketError::FixedHeaderError(header_err) => {
+            if let FixedHeaderError::IoError(io_err) = header_err {
+                if let ErrorKind::ConnectionReset = io_err.kind() {
+                    warn!("Connection to MQTT broker was reset!");
+                    return PacketReceiveError::ConnectionReset;
+                } else {
+                    error!("Unexpected IoError! {:?}", io_err);
+                }
+            } else {
+                error!("Unexpected FixedHeaderError! {:?}", header_err);
+            }
+        }
+        _ => {
+            error!("Error in receiving packet {:?}", error);
+        }
+    }
+
+    PacketReceiveError::Other
 }


### PR DESCRIPTION
When the connection gets reset (disconnected for various reasons)
we need to try to reconnect, otherwise we will stop logging
forever if the MQTT broker ever goes down temporarily for any
reason.  This change allows the linkstation-monitor to try
to reconnect when it detects this problem.